### PR TITLE
change agreement from MIT to GPL V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,6 @@ qiniu-js-sdk
 
 > Copyright (c) 2014 qiniu.com
 
-## 基于 MIT 协议发布:
+## 基于 GPL V2 协议发布:
 
-> [www.opensource.org/licenses/MIT](http://www.opensource.org/licenses/MIT)
+> [www.gnu.org/licenses/gpl-2.0.html](http://www.gnu.org/licenses/gpl-2.0.html)


### PR DESCRIPTION
Plupload协议是GPL V2，因为GPL协议的继承性，将JS SDK的协议修改为 GPL V2。
