### PR TITLE
修复：uptoken_url 或者 domain其中一个不能为空

### DIFF
--- a/src/qiniu.js
+++ b/src/qiniu.js
@@ -231,7 +231,7 @@ function QiniuJsSDK() {
     var that = this;
 
     this.uploader = function(op) {
-        if (!op.domain) {
+        if (!(!op.domain || !uptoken_url)) {
             throw 'uptoken_url or domain is required!';
         }
 


### PR DESCRIPTION
Fixed: #115