### PR TITLE
修复向私有空间上传图片拉取exif,imageInfo,imageView的错误

### DIFF
--- a/demo/scripts/ui.js
+++ b/demo/scripts/ui.js
@@ -251,7 +251,12 @@ FileProgress.prototype.setComplete = function(up, info) {
 
         var img = new Image();
         if (!/imageView/.test(url)) {
-            url += imageView
+            if (typeof Qiniu.downtoken_url != "undefined") {
+                info = Qiniu.downloadToken(res.key + imageView);
+                url = info.url;
+            } else {
+                url += imageView;
+            }
         }
         $(img).attr('src', url);
 
@@ -327,8 +332,15 @@ FileProgress.prototype.setComplete = function(up, info) {
             if (!(ie && ie <= 9)) {
                 var exif = Qiniu.exif(res.key);
                 if (exif) {
+                    var exif_url = "";
                     var exifLink = $('<a href="" target="_blank">查看exif</a>');
-                    exifLink.attr('href', url + '?exif');
+                    if (typeof Qiniu.downtoken_url != "undefined") {
+                        info = Qiniu.downloadToken(res.key + "?exif");
+                        exif_url = info.url;
+                    } else {
+                        exif_url = url + "?exif";
+                    }
+                    exifLink.attr('href',exif_url);
                     infoWrapper.append(exifLink);
                 }
 

--- a/dist/qiniu.js
+++ b/dist/qiniu.js
@@ -471,6 +471,32 @@ function QiniuJsSDK() {
     };
 
     /**
+     * get private download token
+     * @param  {String} key of file
+     * @return {object} parsed json object from downtoken_url
+     */
+    this.downloadToken = function(key) {
+        // if op.dowontoken_url is not empty
+        var ajax_downtoken = that.createAjax();
+        var res_downtoken;
+        ajax_downtoken.open('POST', this.downtoken_url, false);
+        ajax_downtoken.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+        ajax_downtoken.onreadystatechange = function() {
+            if (ajax_downtoken.readyState === 4) {
+                if (ajax_downtoken.status === 200) {
+                    try {
+                        res_downtoken = that.parseJSON(ajax_downtoken.responseText);
+                    } catch (e) {
+                        throw ('invalid json format');
+                    }
+                }
+            }
+        };
+        ajax_downtoken.send("key=" + key);
+        return res_downtoken;
+    };
+
+    /**
      * create a uploader by QiniuJsSDK
      * @param  {object} options to create a new uploader
      * @return {object} uploader
@@ -612,6 +638,9 @@ function QiniuJsSDK() {
         that.token = '';
         that.key_handler = typeof op.init.Key === 'function' ? op.init.Key : '';
         this.domain = op.domain;
+        if (op.downtoken_url) {
+            this.downtoken_url = op.downtoken_url;
+        }
         // TODO: ctx is global in scope of a uploader instance
         // this maybe cause error
         var ctx = '';
@@ -778,7 +807,7 @@ function QiniuJsSDK() {
                     directUpload(up, file, that.key_handler);
                 } else {
                     // TODO: need a polifill to make it work in IE 9-
-                    // ISSUE: if file.name is existed in localStorage 
+                    // ISSUE: if file.name is existed in localStorage
                     // but not the same file maybe cause error
                     var localFileInfo = localStorage.getItem(file.name);
                     var blockSize = chunk_size;
@@ -797,7 +826,7 @@ function QiniuJsSDK() {
 
                             if (localFileInfo.percent !== 100) {
                                 if (file.size === localFileInfo.total) {
-                                    // TODO: if file.name and file.size is the same 
+                                    // TODO: if file.name and file.size is the same
                                     // but not the same file will cause error
                                     file.percent = localFileInfo.percent;
                                     file.loaded = localFileInfo.offset;
@@ -1065,7 +1094,7 @@ function QiniuJsSDK() {
 
                 var res = that.parseJSON(info.response);
                 ctx = ctx ? ctx : res.ctx;
-                // if ctx is not empty 
+                // if ctx is not empty
                 //      that means the upload strategy is chunk upload
                 //      befroe the invoke the last_step
                 //      we need request the mkfile to compose all uploaded chunks
@@ -1304,7 +1333,14 @@ function QiniuJsSDK() {
         if (!key) {
             return false;
         }
-        var url = this.getUrl(key) + '?imageInfo';
+        var url = "";
+        var key = key + '?imageInfo';
+        if (typeof this.downtoken_url != "undefined") {
+            res_downtoken = this.downloadToken(key);
+            url = res_downtoken.url;
+        } else {
+            url = this.getUrl(key);
+        }
         var xhr = this.createAjax();
         var info;
         var that = this;
@@ -1327,7 +1363,14 @@ function QiniuJsSDK() {
         if (!key) {
             return false;
         }
-        var url = this.getUrl(key) + '?exif';
+        var url = "";
+        var key = key + '?exif';
+        if (typeof this.downtoken_url != "undefined") {
+            res_downtoken = this.downloadToken(key);
+            url = res_downtoken.url;
+        } else {
+            url = this.getUrl(key);
+        }
         var xhr = this.createAjax();
         var info;
         var that = this;


### PR DESCRIPTION
水印等操作没有测试，ui里的demo按照exif等修改，应该也可以办到。
另: 私有仓库获得图片exif等信息的说明并没有体现的很明显，麻烦在相应的文档上说明一下。
