### PR TITLE
为 mkfile 错误时的 handler 添加 http headers

### DIFF
--- a/src/qiniu.js
+++ b/src/qiniu.js
@@ -1335,7 +1335,8 @@ function QiniuJsSDK() {
                                     status: ajax.status,
                                     response: ajax.responseText,
                                     file: file,
-                                    code: -200
+                                    code: -200,
+                                    responseHeaders: ajax.getAllResponseHeaders()
                                 };
                                 logger.debug("mkfile is error: ", info);
                                 uploader.trigger('Error', info);


### PR DESCRIPTION
以便于调试 mkfile 错误的原因