### PR TITLE
statistics_report 兼容H2

### DIFF
--- a/src/qiniu.js
+++ b/src/qiniu.js
@@ -1511,7 +1511,7 @@
 
                     // send statistics log
                     if (!op.disable_statistics_report) {
-                        var req_id = info.responseHeaders.match(/(X-Reqid\:\ )([\w\.\%-]*)/)[2];
+                        var req_id = info.responseHeaders.match(/(X-Reqid\:\ )([\w\.\%-]*)/i)[2];
                         var startAt = file._start_at ? file._start_at.getTime() : nowTime.getTime();
                         statisticsLogger.log(
                             info.status,


### PR DESCRIPTION
在H2中，req和res的字段都是为小写，正则需要匹配大小写，否则会报错