### PR TITLE
修复#244

### DIFF
--- a/src/qiniu.js
+++ b/src/qiniu.js
@@ -1548,14 +1548,15 @@
                 // add cancel log
                 if (!op.disable_statistics_report) {
                     for (var i = 0; i < files.length; i++) {
+                        var startAt = files[i]._start_at ? files[i]._start_at.getTime() : nowTime.getTime();
                         statisticsLogger.log(
                             ExtraErrors.Cancelled,
                             undefined,
                             getDomainFromUrl(up.settings.url),
                             undefined,
                             getPortFromUrl(up.settings.url),
-                            (nowTime.getTime() - files[i]._start_at.getTime())/1000,
-                            files[i]._start_at.getTime()/1000,
+                            (nowTime.getTime() - startAt)/1000,
+                            parseInt(startAt/1000),
                             files[i].size * files[i].percent / 100,
                             "jssdk-" + up.runtime,
                             files[i].size


### PR DESCRIPTION
修复#244中提到的调用removeFile导致出错的问题
修复FilesRemoved事件中对_start_at属性访问时没有检测是否存在导致崩溃的bug