### PR TITLE
添加图片压缩功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ subscription.unsubscribe() // 上传取消
      "Domain": "<Your Bucket Domain>" // Bucket 的外链默认域名，在 Bucket 的内容管理里查看，如：'http://xxx.bkt.clouddn.com/'
    }
    ```
-2. 进入项目根目录，执行 `npm install` 安装依赖库，然后打开两个终端，一个执行 `npm run serve` 跑 server， 一个执行 `npm run dev` 运行服务 demo1； demo2 为测试es6语法的 demo，进入 demo2 目录，执行 `npm install`，然后 `npm start` 运行 demo2，demo1 和 demo2 都共用一个 server，请注意 server 文件里的 `region` 设置跟 `config` 里的` region` 设置要保持一致。
+2. 进入项目根目录，执行 `npm install` 安装依赖库，然后打开两个终端，一个执行 `npm run serve` 跑 server， 一个执行 `npm run dev` 运行服务 demo1，地址栏中的 demo1 改为 demo3 则进入 demo3 相应页面； demo2 为测试 es6 语法的 demo，进入 demo2 目录，执行 `npm install`，然后 `npm start` 运行 demo2；demo3为测试图片压缩功能的示例，demo1、demo2 和 demo3 都共用一个 server，请注意 server 文件里的 `region` 设置跟 `config` 里的` region` 设置要保持一致。
 
 
 <a id="note"></a>

--- a/README.md
+++ b/README.md
@@ -251,6 +251,31 @@ subscription.unsubscribe() // 上传取消
     multipart_params_obj[k[0]] = k[1]
   }
   ```
+### qiniu.compressImage(file: blob, options: object) : Promise (图片压缩)
+
+  ```JavaScript
+  var imgLink = qiniu.compressImage(file, options).then(res => {
+    // res : {
+    //   dist: 压缩后的 blob 对象，图片压缩后的文件如果比原来还大则默认返回源文件
+    //   width: 压缩后的图片宽度
+    //   height: 压缩后的图片高度
+    // }
+    }
+  })
+  ```
+  * file: 要压缩的源图片，为 `blob` 对象
+  * options: `object`
+
+    ```JavaScript
+      var options = {
+        quality: 0.92,
+        maxWidth: 1000,
+        maxHeight: 618
+      }
+    ```
+    * options.quality: `number`，图片压缩质量，在指定图片格式为 `image/jpeg` 或 `image/webp` 的情况下，可以从 0 到 1 的区间内选择图片的质量。如果超出取值范围，将会使用默认值 0.92
+    * options.maxWidh: `number`，压缩图片的最大宽度值
+    * options.maxHeight: `number`，压缩图片的最大高度值
 
 ### qiniu.watermark(options: object, key: string, domain: string): string（水印）
 

--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ subscription.unsubscribe() // 上传取消
      "Domain": "<Your Bucket Domain>" // Bucket 的外链默认域名，在 Bucket 的内容管理里查看，如：'http://xxx.bkt.clouddn.com/'
    }
    ```
-2. 进入项目根目录，执行 `npm install` 安装依赖库，然后打开两个终端，一个执行 `npm run serve` 跑 server， 一个执行 `npm run dev` 运行服务 demo1，地址栏中的 demo1 改为 demo3 则进入 demo3 相应页面； demo2 为测试 es6 语法的 demo，进入 demo2 目录，执行 `npm install`，然后 `npm start` 运行 demo2；demo3为测试图片压缩功能的示例，demo1、demo2 和 demo3 都共用一个 server，请注意 server 文件里的 `region` 设置跟 `config` 里的` region` 设置要保持一致。
+2. 进入项目根目录，执行 `npm install` 安装依赖库，然后打开两个终端，一个执行 `npm run serve` 跑 server， 一个执行 `npm run dev` 运行服务；demo1：`http://0.0.0.0:8080/test/demo1`；demo3：`http://0.0.0.0:8080/test/demo3`；demo1为测试上传功能的示例，demo3为测试图片压缩功能的示例；demo2 为测试 es6 语法的示例，进入 demo2 目录，执行 `npm install`，然后 `npm start` 运行 demo2；demo1、demo2 和 demo3 都共用一个 server，请注意 server 文件里的 `region` 设置跟 `config` 里的` region` 设置要保持一致。
 
 
 <a id="note"></a>

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ subscription.unsubscribe() // 上传取消
   ```JavaScript
   var imgLink = qiniu.compressImage(file, options).then(res => {
     // res : {
-    //   dist: 压缩后的 blob 对象，设置 noCompressIfLarger 为 true 时， 如果发现压缩后图片大小比原来还大，则返回源图片
+    //   dist: 压缩后输出的 blob 对象，或原始的 file，具体看下面的 options 配置
     //   width: 压缩后的图片宽度
     //   height: 压缩后的图片高度
     // }
@@ -269,7 +269,7 @@ subscription.unsubscribe() // 上传取消
     * options.maxWidh: `number`，压缩图片的最大宽度值
     * options.maxHeight: `number`，压缩图片的最大高度值
     （注意：当 `maxWidth` 和 `maxHeight` 都不设置时，则采用原图尺寸大小）
-    * options.noCompressIfLarger: `boolean`，为 `true` 时如果发现压缩后图片大小比原来还大，则返回源图片，并不会改变尺寸大小，默认 `false`
+    * options.noCompressIfLarger: `boolean`，为 `true` 时如果发现压缩后图片大小比原来还大，则返回源图片（即输出的 dist 直接返回了输入的 file）；默认 `false`，即保证图片尺寸符合要求，但不保证压缩后的图片体积一定变小
 
 ### qiniu.watermark(options: object, key: string, domain: string): string（水印）
 

--- a/README.md
+++ b/README.md
@@ -256,20 +256,20 @@ subscription.unsubscribe() // 上传取消
   ```JavaScript
   var imgLink = qiniu.compressImage(file, options).then(res => {
     // res : {
-    //   dist: 压缩后的 blob 对象，图片压缩后的文件如果比原来还大则默认返回源文件
+    //   dist: 压缩后的 blob 对象，设置 noCompressIfLarger 为 true 时， 如果发现压缩后图片大小比原来还大，则返回源图片
     //   width: 压缩后的图片宽度
     //   height: 压缩后的图片高度
     // }
     }
   })
   ```
-  * file: 要压缩的源图片，为 `blob` 对象，支持 `image/png`、`image/jpeg`、`image/bmp`、`mage/webp` 等图片类型
+  * file: 要压缩的源图片，为 `blob` 对象，支持 `image/png`、`image/jpeg`、`image/bmp`、`image/webp` 这几种图片类型
   * options: `object`
-    * options.quality: `number`，图片压缩质量，在指定图片格式为 `image/jpeg` 或 `image/webp` 的情况下，可以从 0 到 1 的区间内选择图片的质量。默认值 0.92
+    * options.quality: `number`，图片压缩质量，在图片格式为 `image/jpeg` 或 `image/webp` 的情况下生效，其他格式不会生效，可以从 0 到 1 的区间内选择图片的质量。默认值 0.92
     * options.maxWidh: `number`，压缩图片的最大宽度值
     * options.maxHeight: `number`，压缩图片的最大高度值
     （注意：当 `maxWidth` 和 `maxHeight` 都不设置时，则采用原图尺寸大小）
-    * options.noCompressIfLarger: `boolean`，为 `true` 时如果发现压缩后文件大小比原来还大，则使用原来图片，默认 `false`
+    * options.noCompressIfLarger: `boolean`，为 `true` 时如果发现压缩后图片大小比原来还大，则返回源图片，并不会改变尺寸大小，默认 `false`
 
 ### qiniu.watermark(options: object, key: string, domain: string): string（水印）
 

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ subscription.unsubscribe() // 上传取消
     }
   })
   ```
-  * file: 要压缩的源图片，为 `blob` 对象
+  * file: 要压缩的源图片，为 `blob` 对象，支持 `image/png`、`image/jpeg`、`image/bmp`、`mage/webp` 等图片类型
   * options: `object`
     * options.quality: `number`，图片压缩质量，在指定图片格式为 `image/jpeg` 或 `image/webp` 的情况下，可以从 0 到 1 的区间内选择图片的质量。默认值 0.92
     * options.maxWidh: `number`，压缩图片的最大宽度值

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Qiniu-JavaScript-SDK 的示例 [Demo](http://jssdk-v2.demo.qiniu.io) 中的服�
 
 ### Example
 
+文件上传：
+
 ```JavaScript
 
 var observable = qiniu.upload(file, key, token, putExtra, config)
@@ -115,7 +117,20 @@ var subscription = observable.subscribe(next, error, complete) // 这样传参�
 
 subscription.unsubscribe() // 上传取消
 ```
+图片上传前压缩：
 
+```JavaScript
+let options = {
+  quality: 0.92,
+  noCompressIfLarger: true
+  // maxWidth: 1000,
+  // maxHeight: 618
+}
+qiniu.compressImage(file, options).then(data => {
+  var observable = qiniu.upload(data.dist, key, token, putExtra, config)
+  var subscription = observable.subscribe(observer) // 上传开始
+})
+```
 ## API Reference Interface
 
 ### qiniu.upload(file: blob, key: string, token: string, putExtra: object, config: object): observable
@@ -251,7 +266,7 @@ subscription.unsubscribe() // 上传取消
     multipart_params_obj[k[0]] = k[1]
   }
   ```
-### qiniu.compressImage(file: blob, options: object) : Promise (图片压缩)
+### qiniu.compressImage(file: blob, options: object) : Promise (上传前图片压缩)
 
   ```JavaScript
   var imgLink = qiniu.compressImage(file, options).then(res => {

--- a/README.md
+++ b/README.md
@@ -265,17 +265,11 @@ subscription.unsubscribe() // 上传取消
   ```
   * file: 要压缩的源图片，为 `blob` 对象
   * options: `object`
-
-    ```JavaScript
-      var options = {
-        quality: 0.92,
-        maxWidth: 1000,
-        maxHeight: 618
-      }
-    ```
-    * options.quality: `number`，图片压缩质量，在指定图片格式为 `image/jpeg` 或 `image/webp` 的情况下，可以从 0 到 1 的区间内选择图片的质量。如果超出取值范围，将会使用默认值 0.92
+    * options.quality: `number`，图片压缩质量，在指定图片格式为 `image/jpeg` 或 `image/webp` 的情况下，可以从 0 到 1 的区间内选择图片的质量。默认值 0.92
     * options.maxWidh: `number`，压缩图片的最大宽度值
     * options.maxHeight: `number`，压缩图片的最大高度值
+    （注意：当 `maxWidth` 和 `maxHeight` 都不设置时，则采用原图尺寸大小）
+    * options.noCompressIfLarger: `boolean`，为 `true` 时如果发现压缩后文件大小比原来还大，则使用原来图片，默认 `false`
 
 ### qiniu.watermark(options: object, key: string, domain: string): string（水印）
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qiniu-js",
   "jsName": "qiniu",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "private": false,
   "description": "Javascript SDK for Qiniu Resource (Cloud) Storage AP",
   "main": "dist/qiniu.min.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qiniu-js",
   "jsName": "qiniu",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "private": false,
   "description": "Javascript SDK for Qiniu Resource (Cloud) Storage AP",
   "main": "dist/qiniu.min.js",
@@ -53,7 +53,8 @@
     "uglifyjs-webpack-plugin": "^1.1.6",
     "webpack": "^3.6.0",
     "webpack-dev-server": "^2.9.1",
-    "webpack-merge": "^4.1.1"
+    "webpack-merge": "^4.1.1",
+    "exif-js": "^2.3.0"
   },
   "license": "MIT"
 }

--- a/src/compress.js
+++ b/src/compress.js
@@ -1,0 +1,185 @@
+import { EXIF } from "exif-js";
+import { createObjectURL, getTransform } from "./utils";
+
+let MIME_TYPES = {
+  PNG: "image/png",
+  JPEG: "image/jpeg",
+  WEBP: "image/webp",
+};
+
+let MAX_STEPS = 4;
+let SCALE_FACTOR = Math.log(2);
+let SUPPORT_MIME_TYPES = Object.keys(MIME_TYPES).map(type => MIME_TYPES[type]);
+let DEFAULT_TYPE = MIME_TYPES.JPEG;
+
+function isSupportedType(type) {
+  return SUPPORT_MIME_TYPES.includes(type);
+}
+
+export class Compress {
+  constructor(option){
+    this.config = Object.assign(
+      {
+        maxWidth: 1600,
+        maxHeight: 1600,
+        quality:0.92
+      },
+      option
+    );
+  }
+
+  process(file){
+    this.outputType = file.type;
+    let srcDimension = {};
+    let distDimension = {};
+
+    if (!file.type.match(/^image/)) {
+      return Promise.reject(new Error(`unsupport file type: ${file.type}`));
+    } 
+    if (!isSupportedType(file.type)) {
+      this.outputType = DEFAULT_TYPE;
+      console.warn(`unsupported MIME type ${file.type}, will fallback to default ${DEFAULT_TYPE}`);
+    }
+
+    return this.getOriginImage(file)
+    .then(img => {
+      srcDimension.width = img.width;
+      srcDimension.height = img.height;
+      return this.getOriginInfo(img);
+    })
+    .then(canvas => {
+      // 计算图片缩小比例，取最小值，如果大于1则保持图片原尺寸
+      let scale = Math.min(1, this.config.maxWidth / canvas.width, this.config.maxHeight / canvas.height);
+      return this.drawImage(canvas, scale);
+    })
+    .then(result => {
+      let newImageURL = result.toDataURL(this.outputType, this.config.quality);
+      let distBlob = this.dataURLToBlob(newImageURL);
+      distDimension.width = result.width;
+      distDimension.height = result.height;
+      if (distBlob.size > file.size){
+        distBlob = file;
+        distDimension = srcDimension;
+      }
+      return ({
+        dist: {
+          blob: distBlob,
+          ...distDimension
+        },
+        source: {
+          blob: file,
+          ...srcDimension
+        }
+      });
+    });
+  }
+
+  clear(ctx, width, height) {
+    // jpeg 没有 alpha 通道，透明区间会被填充成黑色，这里把透明区间填充为白色
+    if (this.outputType === DEFAULT_TYPE) {
+        ctx.fillStyle = "#fff";
+        ctx.fillRect(0, 0, width, height);
+    } else {
+        ctx.clearRect(0, 0, width, height);
+    }
+  }
+  // 通过 file 初始化 image 对象
+  getOriginImage(file){
+    return new Promise((resolve, reject) => {
+      let url = createObjectURL(file);
+      let img = new Image();
+      img.src = url;
+      img.onload = () => {
+        resolve(img);
+      };
+      img.onerror = () => {
+        reject("image load error");
+      };
+    });
+  }
+
+  getOriginInfo(img){
+    return new Promise((resolve, reject) => {
+      // 通过得到图片的信息来调整显示方向以正确显示图片，主要解决 ios 系统上的图片会有旋转的问题
+      EXIF.getData(img, () => {
+        let orientation = EXIF.getTag(img, "Orientation") || 1;
+  
+        let { width, height, matrix } = getTransform(img, orientation);
+        let canvas = document.createElement("canvas");
+        let context = canvas.getContext("2d");
+        canvas.width = width;
+        canvas.height = height;
+        this.clear(context, width, height);
+        context.transform(...matrix);
+        context.drawImage(img, 0, 0);
+        resolve(canvas);
+      });
+    });
+  }
+
+  drawImage(source, scale){
+    if (scale === 1) {
+      return Promise.resolve(source);
+    }
+    // 不要一次性画图，通过设定的 step 次数，渐进式的画图，这样可以增加图片的清晰度，防止一次性画图导致的像素丢失严重
+    let sctx = source.getContext("2d");
+    let steps = Math.min(MAX_STEPS, Math.ceil((1 / scale) / SCALE_FACTOR));
+
+    let factor = Math.pow(scale, 1 / steps);
+
+    let mirror = document.createElement("canvas");
+    let mctx = mirror.getContext("2d");
+
+    let { width, height } = source;
+
+    mirror.width = width;
+    mirror.height = height;
+
+    let i = 0;
+
+    while (i < steps) {
+      let dw = width * factor | 0;
+      let dh = height * factor | 0;
+
+      let src, context;
+
+      if (i % 2 === 0) {
+        src = source;
+        context = mctx;
+      } else {
+        src = mirror;
+        context = sctx;
+      }
+
+      this.clear(context, width, height);
+      context.drawImage(src, 0, 0, width, height, 0, 0, dw, dh);
+
+      i++;
+      width = dw;
+      height = dh;
+
+      if (i === steps) {
+        // get current working canvas
+        let canvas = src === source ? mirror : source;
+
+        // save data
+        let data = context.getImageData(0, 0, width, height);
+
+        // resize
+        canvas.width = width;
+        canvas.height = height;
+
+        // store image data
+        context.putImageData(data, 0, 0);
+
+        return Promise.resolve(canvas);
+      }
+    }
+  }
+  // 这里把 base64 字符串转为 blob 对象
+  dataURLToBlob(dataURL){
+    let buffer = atob(dataURL.split(",")[1]).split("").map(char => char.charCodeAt(0));
+    let blob = new Blob([new Uint8Array(buffer)], { type: this.outputType });
+    return blob;
+  }
+}

--- a/src/compress.js
+++ b/src/compress.js
@@ -30,8 +30,6 @@ class Compress {
   }
 
   process(){
-    console.log(this.config)
-    console.log(this.file)
     this.outputType = this.file.type;
     let distDimension = {}, srcDimension = {};
     if (!this.outputType.match(/^image/)) {
@@ -181,5 +179,6 @@ class Compress {
 
 let compressOutPut = (file, options) => {
   return new Compress(file, options).process();
-}
+};
+
 export default compressOutPut;

--- a/src/compress.js
+++ b/src/compress.js
@@ -20,10 +20,10 @@ function isSupportedType(type) {
 class Compress {
   constructor(file, option){
     this.config = Object.assign(
-      { 
+      {
         quality:0.92,
         noCompressIfLarger:false
-      }, 
+      },
       option
     );
     this.file = file;
@@ -32,9 +32,6 @@ class Compress {
   process(){
     this.outputType = this.file.type;
     let distDimension = {}, srcDimension = {};
-    if (!this.outputType.match(/^image/)) {
-      return Promise.reject(new Error(`unsupport file type: ${this.outputType}`));
-    } 
     if (!isSupportedType(this.outputType)) {
       return Promise.reject(new Error(`unsupport file type: ${this.outputType}`));
     }
@@ -101,7 +98,7 @@ class Compress {
       // 通过得到图片的信息来调整显示方向以正确显示图片，主要解决 ios 系统上的图片会有旋转的问题
       EXIF.getData(img, () => {
         let orientation = EXIF.getTag(img, "Orientation") || 1;
-  
+
         let { width, height, matrix } = getTransform(img, orientation);
         let canvas = document.createElement("canvas");
         let context = canvas.getContext("2d");
@@ -140,7 +137,7 @@ class Compress {
       let dw = width * factor | 0;
       let dh = height * factor | 0;
       // 到最后一步的时候 dw, dh 用 目标缩放尺寸，否则会出现最后尺寸偏小的情况
-      if (i === (steps - 1)) {
+      if (i === steps - 1) {
         dw = originWidth * scale;
         dh = originHeight * scale;
       }
@@ -152,24 +149,25 @@ class Compress {
         src = mirror;
         context = sctx;
       }
+      // 每次画前都清空，避免图像重叠
       this.clear(context, width, height);
       context.drawImage(src, 0, 0, width, height, 0, 0, dw, dh);
       width = dw;
       height = dh;
     }
-      let canvas = src === source ? mirror : source;
 
-      // save data
-      let data = context.getImageData(0, 0, width, height);
+    let canvas = src === source ? mirror : source;
+    // save data
+    let data = context.getImageData(0, 0, width, height);
 
-      // resize
-      canvas.width = width;
-      canvas.height = height;
+    // resize
+    canvas.width = width;
+    canvas.height = height;
 
-      // store image data
-      context.putImageData(data, 0, 0);
+    // store image data
+    context.putImageData(data, 0, 0);
 
-      return Promise.resolve(canvas);
+    return Promise.resolve(canvas);
   }
 
   // 这里把 base64 字符串转为 blob 对象

--- a/src/compress.js
+++ b/src/compress.js
@@ -49,7 +49,7 @@ class Compress {
       if (this.config.maxWidth) {
         scale = Math.min(1, this.config.maxWidth / canvas.width);
       }
-      if(this.config.maxHeight) {
+      if (this.config.maxHeight) {
         scale = Math.min(1, scale, this.config.maxHeight / canvas.height);
       }
       srcDimension.width = canvas.width;
@@ -135,7 +135,7 @@ class Compress {
     mirror.height = height;
     let src, context;
 
-    for(let i = 0; i< steps; i++) {
+    for (let i = 0; i < steps; i++) {
 
       let dw = width * factor | 0;
       let dh = height * factor | 0;

--- a/src/compress.js
+++ b/src/compress.js
@@ -54,14 +54,13 @@ class Compress {
       return this.doScale(canvas, scale);
     })
     .then(result => {
-      let newImageURL = result.toDataURL(this.outputType, this.config.quality);
       let distBlob = this.toBlob(result);
       if (distBlob.size > this.file.size && this.config.noCompressIfLarger){
         return {
           dist: this.file,
           width: srcDimension.width,
           height: srcDimension.height
-        }
+        };
       }
       return ({
         dist: distBlob,
@@ -100,7 +99,6 @@ class Compress {
       // 通过得到图片的信息来调整显示方向以正确显示图片，主要解决 ios 系统上的图片会有旋转的问题
       EXIF.getData(img, () => {
         let orientation = EXIF.getTag(img, "Orientation") || 1;
-
         let { width, height, matrix } = getTransform(img, orientation);
         let canvas = document.createElement("canvas");
         let context = canvas.getContext("2d");

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ import { UploadManager } from "./upload";
 import { imageMogr2, watermark, imageInfo, exif, pipeline } from "./image";
 import { Observable } from "./observable";
 import { StatisticsLogger } from "./statisticsLog";
-import { Compress } from "./compress.js";
+import  compressImage  from "./compress.js";
 let statisticsLogger = new StatisticsLogger();
 
 function upload(file, key, token, putExtra, config) {
@@ -46,6 +46,6 @@ export {
   watermark,
   imageInfo,
   exif,
-  Compress,
+  compressImage,
   pipeline
 };

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ import { UploadManager } from "./upload";
 import { imageMogr2, watermark, imageInfo, exif, pipeline } from "./image";
 import { Observable } from "./observable";
 import { StatisticsLogger } from "./statisticsLog";
-import  compressImage  from "./compress.js";
+import compressImage from "./compress";
 let statisticsLogger = new StatisticsLogger();
 
 function upload(file, key, token, putExtra, config) {

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ import { UploadManager } from "./upload";
 import { imageMogr2, watermark, imageInfo, exif, pipeline } from "./image";
 import { Observable } from "./observable";
 import { StatisticsLogger } from "./statisticsLog";
-
+import { Compress } from "./compress.js";
 let statisticsLogger = new StatisticsLogger();
 
 function upload(file, key, token, putExtra, config) {
@@ -46,5 +46,6 @@ export {
   watermark,
   imageInfo,
   exif,
+  Compress,
   pipeline
 };

--- a/src/upload.js
+++ b/src/upload.js
@@ -66,7 +66,7 @@ export class UploadManager {
       if (!isContainFileMimeType(this.file.type, this.putExtra.mimeType)){
         let err = new Error("file type doesn't match with what you specify");
         this.onError(err);
-        return Promise.reject(err);
+        return;
       }
     }
     let upload = getUploadUrl(this.config, this.token).then(res => {
@@ -80,7 +80,7 @@ export class UploadManager {
         this.sendLog(res.reqId, 200);
       }
     }, err => {
-      
+
       this.clear();
       if (err.isRequestError && !this.config.disableStatisticsReport) {
         let reqId = this.aborted ? "" : err.reqId;
@@ -203,13 +203,13 @@ export class UploadManager {
     if (savedReusable && !shouldCheckMD5) {
       return reuseSaved();
     }
-    
+
     return computeMd5(chunk).then(md5 => {
 
       if (savedReusable && md5 === info.md5) {
         return reuseSaved();
       }
-      
+
       let headers = getHeadersForChunkUpload(this.token);
       let onProgress = data => {
         this.updateChunkProgress(data.loaded, index);

--- a/src/utils.js
+++ b/src/utils.js
@@ -255,10 +255,8 @@ export function isContainFileMimeType(fileType, mimeType){
 }
 
 export function createObjectURL(file) {
-  if (window.navigator.userAgent.indexOf("Chrome") >= 1 || window.navigator.userAgent.indexOf("Safari") >= 1) { 
-    return window.webkitURL.createObjectURL(file); 
-  } 
-  return window.URL.createObjectURL(file); 
+  let URL = window.URL || window.webkitURL || window.mozURL;
+  return URL.createObjectURL(file) 
 }
 
 export function getTransform(image, orientation) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -253,3 +253,69 @@ function getUpHosts(token) {
 export function isContainFileMimeType(fileType, mimeType){
   return mimeType.indexOf(fileType) > -1;
 }
+
+export function createObjectURL(file) {
+  if (window.navigator.userAgent.indexOf("Chrome") >= 1 || window.navigator.userAgent.indexOf("Safari") >= 1) { 
+    return window.webkitURL.createObjectURL(file); 
+  } 
+  return window.URL.createObjectURL(file); 
+}
+
+export function getTransform(image, orientation) {
+  let { width, height } = image;
+
+  switch (orientation) {
+    case 1:
+      // default
+      return {
+          width, height,
+          matrix: [1, 0, 0, 1, 0, 0]
+      };
+    case 2:
+      // horizontal flip
+      return {
+          width, height,
+          matrix: [-1, 0, 0, 1, width, 0]
+      };
+    case 3:
+      // 180° rotated
+      return {
+          width, height,
+          matrix: [-1, 0, 0, -1, width, height]
+      };
+    case 4:
+      // vertical flip
+      return {
+          width, height,
+          matrix: [1, 0, 0, -1, 0, height]
+      };
+    case 5:
+      // vertical flip + -90° rotated
+      return {
+        width: height,
+        height: width,
+        matrix: [0, 1, 1, 0, 0, 0]
+      };
+    case 6:
+      // -90° rotated
+      return {
+          width: height,
+          height: width,
+          matrix: [0, 1, -1, 0, height, 0]
+        };
+    case 7:
+      // horizontal flip + -90° rotate
+      return {
+          width: height,
+          height: width,
+          matrix: [0, -1, -1, 0, height, width]
+      };
+    case 8:
+      // 90° rotated
+      return {
+          width: height,
+          height: width,
+          matrix: [0, -1, 1, 0, 0, width]
+        };
+  }
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -256,7 +256,7 @@ export function isContainFileMimeType(fileType, mimeType){
 
 export function createObjectURL(file) {
   let URL = window.URL || window.webkitURL || window.mozURL;
-  return URL.createObjectURL(file) 
+  return URL.createObjectURL(file);
 }
 
 export function getTransform(image, orientation) {

--- a/test/demo3/index.html
+++ b/test/demo3/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="zh-cn">
+
+<head>
+  <meta charset="UTF-8">
+  <title>七牛云 - JavaScript SDK</title>
+  <link href="images/favicon.ico" rel="shortcut icon">
+  <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.min.css">
+  <link rel="stylesheet" href="./style.css">
+</head>
+
+<body>
+  <div class="mainContainer">
+    <div class="row" style="margin-top: 20px;">
+      <ul class="tip col-md-12 text-mute">
+        <li>
+          <small>
+            JavaScript SDK 基于 h5 file api 开发，可以上传文件至七牛云存储。
+          </small>
+        </li>
+      </ul>
+    </div>
+    <div id="box">
+      <button class="select-button">选择文件</button>
+      <input class="file-input" type="file" id="select" />
+    </div>
+    <p style="margin-top:30px">
+        <label for="quality">quality: </label>
+        <input type="range" name="quality" id="quality" min="0" max="1" step="0.01">
+        <span class="option-value"></span>
+    </p>
+    <p>
+        <label for="width">max width: </label>
+        <input type="range" name="maxWidth" id="width" min="100" max="1600">
+        <span class="option-value"></span>
+    </p>
+    <p>
+        <label for="height">max height: </label>
+        <input type="range" name="maxHeight" id="height" min="100" max="1600">
+        <span class="option-value"></span>
+    </p>
+    <div class= "imageContainer">
+      <div class="sourceImage">
+        <pre></pre>
+        <img>
+      </div>
+      <div class="distImage">
+        <pre></pre>
+        <img>
+      </div>
+    </div>
+  </div>
+</body>
+<style>
+</style>
+<script src="http://cdn.static.runoob.com/libs/jquery/1.10.2/jquery.min.js"></script>
+<script src="//netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
+<script type="text/javascript" src='/dist/qiniu.min.js'></script>
+<script type="text/javascript" src="./index.js"></script>
+
+</html>

--- a/test/demo3/index.html
+++ b/test/demo3/index.html
@@ -53,6 +53,7 @@
 </body>
 <style>
 </style>
+<script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
 <script src="http://cdn.static.runoob.com/libs/jquery/1.10.2/jquery.min.js"></script>
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
 <script type="text/javascript" src='/dist/qiniu.min.js'></script>

--- a/test/demo3/index.js
+++ b/test/demo3/index.js
@@ -1,5 +1,6 @@
 
 var lastFile = null;
+var sourceImage;
 var options = {
   quality: 0.92,
   maxWidth: 1000,
@@ -8,9 +9,14 @@ var options = {
 $("#select").change(function(){
   options.outputType = this.files[0].type;
   console.log(options)
-  compress(this.files[0]);
+  sourceImage = new Image();
+  var sourceUrl = URL.createObjectURL(this.files[0]);
+  sourceImage.src = sourceUrl;
+  sourceImage.onload = () => {
+    compress(this.files[0],sourceImage);
+  }
 })
-
+ 
 $('input[type="range"]').each(function() {
   var name = $(this).attr("name");
   $(this).val(options[name])
@@ -27,17 +33,17 @@ function compress(file){
   lastFile = file;
   console.log("compress")
   console.log(options)
-  var compression = new qiniu.Compress(options);
   URL.revokeObjectURL($(".distImage img").attr("src"));
   URL.revokeObjectURL($(".sourceImage img").attr("src"));
   $(".distImage img").attr("src", "");
   $(".sourceImage img").attr("src", "");
   $(".distImage pre").text("");
   $(".sourceImage pre").text("");
-  compression.process(file).then(data => {
-    $(".distImage img").attr("src", URL.createObjectURL(data.dist.blob))
-    $(".sourceImage img").attr("src", URL.createObjectURL(data.source.blob));
-    $(".distImage pre").text("File size:" + (data.dist.blob.size / 1024).toFixed(2) + "KB" + "\n" + "File type:" + data.dist.blob.type + "\n" + "Dimensions:" + data.dist.width + "*" + data.dist.height + "\n" + "ratio:" + (data.dist.blob.size / data.source.blob.size).toFixed(2) * 100 + "%")
-    $(".sourceImage pre").text("File size:" + (data.source.blob.size / 1024).toFixed(2) + "KB" + "\n" + "File type:" + data.source.blob.type + "\n" + "Dimensions:" + data.source.width + "*" + data.source.height)
+  
+  qiniu.compressImage(file, options).then(data => {
+    $(".distImage img").attr("src", URL.createObjectURL(data.dist))
+    $(".sourceImage img").attr("src", URL.createObjectURL(file));    
+    $(".distImage pre").text("File size:" + (data.dist.size / 1024).toFixed(2) + "KB" + "\n" + "File type:" + data.dist.type + "\n" + "Dimensions:" + data.width + "*" + data.height + "\n" + "ratio:" + (data.dist.size / file.size).toFixed(2) * 100 + "%")
+    $(".sourceImage pre").text("File size:" + (file.size / 1024).toFixed(2) + "KB" + "\n" + "File type:" + file.type + "\n" + "Dimensions:" + sourceImage.width + "*" + sourceImage.height)
   })
 }

--- a/test/demo3/index.js
+++ b/test/demo3/index.js
@@ -1,16 +1,15 @@
 
-var lastFile = null;
-var sourceImage;
-var options = {
+let lastFile = null;
+let sourceImage;
+let options = {
   quality: 0.92,
   maxWidth: 1000,
   maxHeight: 618
 }
 $("#select").change(function(){
   options.outputType = this.files[0].type;
-  console.log(options)
   sourceImage = new Image();
-  var sourceUrl = URL.createObjectURL(this.files[0]);
+  let sourceUrl = URL.createObjectURL(this.files[0]);
   sourceImage.src = sourceUrl;
   sourceImage.onload = () => {
     compress(this.files[0],sourceImage);
@@ -18,7 +17,7 @@ $("#select").change(function(){
 })
  
 $('input[type="range"]').each(function() {
-  var name = $(this).attr("name");
+  let name = $(this).attr("name");
   $(this).val(options[name])
   $(this).next().text(options[name])
   $(this).on("change", function(){

--- a/test/demo3/index.js
+++ b/test/demo3/index.js
@@ -3,6 +3,7 @@ let lastFile = null;
 let sourceImage;
 let options = {
   quality: 0.92,
+  noCompressIfLarger: true
   // maxWidth: 1000,
   // maxHeight: 618
 }
@@ -15,7 +16,7 @@ $("#select").change(function(){
     compress(this.files[0]);
   }
 })
- 
+
 $('input[type="range"]').each(function() {
   let name = $(this).attr("name");
   $(this).val(options[name])
@@ -36,10 +37,10 @@ function compress(file){
   $(".sourceImage img").attr("src", "");
   $(".distImage pre").text("");
   $(".sourceImage pre").text("");
-  
+
   qiniu.compressImage(file, options).then(data => {
     $(".distImage img").attr("src", URL.createObjectURL(data.dist))
-    $(".sourceImage img").attr("src", URL.createObjectURL(file));    
+    $(".sourceImage img").attr("src", URL.createObjectURL(file));
     $(".distImage pre").text("File size:" + (data.dist.size / 1024).toFixed(2) + "KB" + "\n" + "File type:" + data.dist.type + "\n" + "Dimensions:" + data.width + "*" + data.height + "\n" + "ratio:" + (data.dist.size / file.size).toFixed(2) * 100 + "%")
     $(".sourceImage pre").text("File size:" + (file.size / 1024).toFixed(2) + "KB" + "\n" + "File type:" + file.type + "\n" + "Dimensions:" + sourceImage.width + "*" + sourceImage.height)
   }).catch(res => {

--- a/test/demo3/index.js
+++ b/test/demo3/index.js
@@ -1,0 +1,43 @@
+
+var lastFile = null;
+var options = {
+  quality: 0.92,
+  maxWidth: 1000,
+  maxHeight: 618
+}
+$("#select").change(function(){
+  options.outputType = this.files[0].type;
+  console.log(options)
+  compress(this.files[0]);
+})
+
+$('input[type="range"]').each(function() {
+  var name = $(this).attr("name");
+  $(this).val(options[name])
+  $(this).next().text(options[name])
+  $(this).on("change", function(){
+    options = Object.assign(options, {[name]: +$(this).val()});
+    $(this).next().text(options[name])
+    compress();
+  })
+})
+
+function compress(file){
+  file = file || lastFile;
+  lastFile = file;
+  console.log("compress")
+  console.log(options)
+  var compression = new qiniu.Compress(options);
+  URL.revokeObjectURL($(".distImage img").attr("src"));
+  URL.revokeObjectURL($(".sourceImage img").attr("src"));
+  $(".distImage img").attr("src", "");
+  $(".sourceImage img").attr("src", "");
+  $(".distImage pre").text("");
+  $(".sourceImage pre").text("");
+  compression.process(file).then(data => {
+    $(".distImage img").attr("src", URL.createObjectURL(data.dist.blob))
+    $(".sourceImage img").attr("src", URL.createObjectURL(data.source.blob));
+    $(".distImage pre").text("File size:" + (data.dist.blob.size / 1024).toFixed(2) + "KB" + "\n" + "File type:" + data.dist.blob.type + "\n" + "Dimensions:" + data.dist.width + "*" + data.dist.height + "\n" + "ratio:" + (data.dist.blob.size / data.source.blob.size).toFixed(2) * 100 + "%")
+    $(".sourceImage pre").text("File size:" + (data.source.blob.size / 1024).toFixed(2) + "KB" + "\n" + "File type:" + data.source.blob.type + "\n" + "Dimensions:" + data.source.width + "*" + data.source.height)
+  })
+}

--- a/test/demo3/index.js
+++ b/test/demo3/index.js
@@ -3,8 +3,8 @@ let lastFile = null;
 let sourceImage;
 let options = {
   quality: 0.92,
-  maxWidth: 1000,
-  maxHeight: 618
+  // maxWidth: 1000,
+  // maxHeight: 618
 }
 $("#select").change(function(){
   options.outputType = this.files[0].type;
@@ -12,7 +12,7 @@ $("#select").change(function(){
   let sourceUrl = URL.createObjectURL(this.files[0]);
   sourceImage.src = sourceUrl;
   sourceImage.onload = () => {
-    compress(this.files[0],sourceImage);
+    compress(this.files[0]);
   }
 })
  
@@ -30,8 +30,6 @@ $('input[type="range"]').each(function() {
 function compress(file){
   file = file || lastFile;
   lastFile = file;
-  console.log("compress")
-  console.log(options)
   URL.revokeObjectURL($(".distImage img").attr("src"));
   URL.revokeObjectURL($(".sourceImage img").attr("src"));
   $(".distImage img").attr("src", "");
@@ -44,5 +42,7 @@ function compress(file){
     $(".sourceImage img").attr("src", URL.createObjectURL(file));    
     $(".distImage pre").text("File size:" + (data.dist.size / 1024).toFixed(2) + "KB" + "\n" + "File type:" + data.dist.type + "\n" + "Dimensions:" + data.width + "*" + data.height + "\n" + "ratio:" + (data.dist.size / file.size).toFixed(2) * 100 + "%")
     $(".sourceImage pre").text("File size:" + (file.size / 1024).toFixed(2) + "KB" + "\n" + "File type:" + file.type + "\n" + "Dimensions:" + sourceImage.width + "*" + sourceImage.height)
+  }).catch(res => {
+    console.log(res)
   })
 }

--- a/test/demo3/style.css
+++ b/test/demo3/style.css
@@ -1,0 +1,72 @@
+body {
+  background-color: rgb(249, 249, 249);
+}
+.navbar {
+  background-color: #fff;
+}
+.mainContainer {
+  position: relative;
+  top: 52px;
+}
+.mainContainer {
+  width: 1170px;
+  margin: 0 auto;
+  padding: 15px 15px;
+}
+.mainContainer .row .tip li {
+  list-style: none;
+}
+.mainContainer .nav-box ul li a {
+  color: #777;
+}
+#box,
+#box2 {
+  margin-top: 20px;
+  height: 46px;
+}
+.fragment-group {
+  overflow: hidden;
+  padding-left: 0;
+}
+.hide {
+  visibility: hidden;
+}
+.fragment-group .fragment {
+  float: left;
+  width: 30%;
+  padding-right: 10px;
+  list-style: none;
+  margin-top: 10px;
+}
+.file-input {
+  display: inline-block;
+  box-sizing: border-box;
+  width: 130px;
+  height: 46px;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.mainContainer .select-button {
+  position: absolute;
+  background-color: #00b7ee;
+  color: #fff;
+  font-size: 18px;
+  padding: 0 30px;
+  line-height: 44px;
+  font-weight: 100;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
+}
+.sourceImage,.distImage{
+  float: left;
+  max-width: 500px;
+  max-height: 500px;
+}
+pre{
+  border:none
+}
+.imageContainer img{
+  max-width: 100%;
+  max-height: 100%
+}
+


### PR DESCRIPTION
* option: {
  quality: 0.92, // 压缩质量
  maxWidth: 1000, // 输出的最大宽度
  maxHeight: 618 // 输出最大高度
  noCompressIfLarger: false
}
* qiniu.compressImage(file, option).then(res => {
// res: { dist: blob, widht: // 压缩后宽度，height: // 压缩后高度 }
})
这里保留了宽高是因为考虑到options里设置了宽高，那么用户会自然去想要知道压缩后的宽高，虽然用户可以通过一些措施操作file来拿到，但是会比较繁琐，所以这里给出方便用户去参考

* exif-js 40kb,压缩后增加了qiniu.mine.js 17kb
* 通过step-down的方式确保图片质量
[参考1](https://stackoverflow.com/questions/17861447/html5-canvas-drawimage-how-to-apply-antialiasing)
[参考2](https://github.com/idiotWu/canvas-compress)