### PR TITLE
修复一些低版本浏览器因xhr的upload.progress触发异常导致的报错问题

### DIFF
--- a/src/upload.js
+++ b/src/upload.js
@@ -43,7 +43,7 @@ export class UploadManager {
       options.putExtra
     );
     this.statisticsLogger = statisticsLogger;
-    this.progress = null;
+    this.progress = {};
     this.xhrList = [];
     this.xhrHandler = xhr => this.xhrList.push(xhr);
     this.aborted = false;


### PR DESCRIPTION
只是修复了报错问题 低版本下的upload的progress触发异常问题还是存在
具体表现为 xhr.readyState先进入第4阶段 upload的progress在这之后触发 而且只触发一次(待更多确认)