### PR TITLE
修复单位比较错误的问题

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qiniu-js",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qiniu-js",
   "jsName": "qiniu",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "private": false,
   "description": "Javascript SDK for Qiniu Resource (Cloud) Storage AP",
   "main": "lib/index.js",

--- a/src/upload/index.ts
+++ b/src/upload/index.ts
@@ -2,6 +2,7 @@ import Resume from './resume'
 import Direct from './direct'
 import { UploadOptions, UploadHandler } from './base'
 import StatisticsLogger from '../statisticsLog'
+import { MB } from '../utils'
 
 export * from './base'
 export * from './resume'
@@ -15,7 +16,7 @@ export default function createUploadManager(
     return new Direct(options, handlers, statisticsLogger)
   }
 
-  return options.file.size > 4 * 1024 * 1024
+  return options.file.size > 4 * MB
     ? new Resume(options, handlers, statisticsLogger)
     : new Direct(options, handlers, statisticsLogger)
 }

--- a/src/upload/index.ts
+++ b/src/upload/index.ts
@@ -1,6 +1,6 @@
 import Resume from './resume'
 import Direct from './direct'
-import { UploadOptions, UploadHandler, DEFAULT_CHUNK_SIZE } from './base'
+import { UploadOptions, UploadHandler } from './base'
 import StatisticsLogger from '../statisticsLog'
 
 export * from './base'
@@ -15,7 +15,7 @@ export default function createUploadManager(
     return new Direct(options, handlers, statisticsLogger)
   }
 
-  return options.file.size > DEFAULT_CHUNK_SIZE
+  return options.file.size > 4 * 1024 * 1024
     ? new Resume(options, handlers, statisticsLogger)
     : new Direct(options, handlers, statisticsLogger)
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import SparkMD5 from 'spark-md5'
 import { Progress, LocalInfo } from './upload'
 import { urlSafeBase64Decode } from './base64'
 
-const MB = 1024 ** 2
+export const MB = 1024 ** 2
 
 // 文件分块
 export function getChunks(file: File, blockSize: number): Blob[] {


### PR DESCRIPTION
fixes #452  判断是否分片上传时，`file.size` 与 `DEFAULT_CHUNK_SIZE` 比较时单位未统一