### PR TITLE
修复从 token 解析 bucket 的 bug & 完善下类型 & fix issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qiniu-js",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qiniu-js",
   "jsName": "qiniu",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "private": false,
   "description": "Javascript SDK for Qiniu Resource (Cloud) Storage AP",
   "main": "lib/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,8 @@ export {
   getHeadersForChunkUpload
 } from './utils'
 
+export { urlSafeBase64Encode, urlSafeBase64Decode } from './base64'
+
 export { CompressResult } from './compress'
 
 export { deleteUploadedChunks, getUploadUrl } from './api'

--- a/src/upload/base.ts
+++ b/src/upload/base.ts
@@ -126,8 +126,11 @@ export default abstract class Base {
     this.onData = handlers.onData
     this.onError = handlers.onError
     this.onComplete = handlers.onComplete
-
-    this.bucket = utils.getPutPolicy(this.token).bucket
+    try {
+      this.bucket = utils.getPutPolicy(this.token).bucket
+    } catch (e) {
+      this.onError(e)
+    }
   }
 
   public async putFile(): Promise<utils.ResponseSuccess<UploadCompleteData>> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -273,7 +273,7 @@ interface PutPolicy {
 export function getPutPolicy(token: string) {
   const segments = token.split(':')
   const ak = segments[0]
-  const putPolicy: PutPolicy = JSON.parse(urlSafeBase64Decode(segments[2]))
+  const putPolicy: PutPolicy = JSON.parse(urlSafeBase64Decode(segments[segments.length - 1]))
 
   return {
     ak,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -272,6 +272,7 @@ interface PutPolicy {
 
 export function getPutPolicy(token: string) {
   const segments = token.split(':')
+  // token 构造的差异参考：https://github.com/qbox/product/blob/master/kodo/auths/UpToken.md#admin-uptoken-authorization
   const ak = segments.length > 3 ? segments[1] : segments[0]
   const putPolicy: PutPolicy = JSON.parse(urlSafeBase64Decode(segments[segments.length - 1]))
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -272,7 +272,7 @@ interface PutPolicy {
 
 export function getPutPolicy(token: string) {
   const segments = token.split(':')
-  const ak = segments[0]
+  const ak = segments.length > 3 ? segments[1] : segments[0]
   const putPolicy: PutPolicy = JSON.parse(urlSafeBase64Decode(segments[segments.length - 1]))
 
   return {


### PR DESCRIPTION
* 由于 ecloud 里 token 加入了 uid 等参数，所以实际格式并不是两个冒号，token 冒号分割后解析 bucket 时，应该取最后的解析
![image](https://user-images.githubusercontent.com/25814552/85998146-02be0380-ba3d-11ea-85de-25a654383275.png)
<img width="1066" alt="企业微信截图_20db6ea8-aaf4-4852-8b48-2cd5b3df59a3" src="https://user-images.githubusercontent.com/25814552/85998369-4a448f80-ba3d-11ea-8cad-9dd1d4e41a22.png">
* 完善下 observable 文件中的类型
* 增加 base64 编解码函数的导出 fix #455 