### PR TITLE
修复图片压缩缩放的 bug

### DIFF
--- a/src/utils/compress.ts
+++ b/src/utils/compress.ts
@@ -135,8 +135,10 @@ class Compress {
         canvas.height = height
 
         this.clear(context, width, height)
+        context.save()
         context.transform(...matrix)
         context.drawImage(img, 0, 0)
+        context.restore()
         resolve(canvas)
       })
     })

--- a/src/utils/compress.ts
+++ b/src/utils/compress.ts
@@ -149,55 +149,53 @@ class Compress {
       return source
     }
     // 不要一次性画图，通过设定的 step 次数，渐进式的画图，这样可以增加图片的清晰度，防止一次性画图导致的像素丢失严重
+    const sctx = source.getContext('2d')
     const steps = Math.min(maxSteps, Math.ceil((1 / scale) / scaleFactor))
+
     const factor = scale ** (1 / steps)
 
-    const { width: originWidth, height: originHeight } = source
+    const mirror = document.createElement('canvas')
+    const mctx = mirror.getContext('2d')
 
-    const mirror1 = source
-    const mirror2 = document.createElement('canvas')
-    const context1 = mirror1.getContext('2d')!
-    const context2 = mirror2.getContext('2d')!
-
-    if (!context1 || !context2) {
+    let { width, height } = source
+    const originWidth = width
+    const originHeight = height
+    mirror.width = width
+    mirror.height = height
+    if (!mctx || !sctx) {
       throw new QiniuError(
         QiniuErrorName.GetCanvasContextFailed,
-        "mirror's context can't be null"
+        "mctx or sctx can't be null"
       )
     }
 
-    let width = originWidth
-    let height = originHeight
-    mirror2.width = width
-    mirror2.height = height
+    let src!: CanvasImageSource
+    let context!: CanvasRenderingContext2D
+    for (let i = 0; i < steps; i++) {
 
-    let src: CanvasImageSource = mirror1
-    let context: CanvasRenderingContext2D = context2
-
-    for (let i = 0; i < steps; ++i) {
-      let dw = (width * factor) | 0 // eslint-disable-line no-bitwise
-      let dh = (height * factor) | 0 // eslint-disable-line no-bitwise
-      // 到最后一步的时候 dw, dh 用目标缩放尺寸
+      let dw = width * factor | 0 // eslint-disable-line no-bitwise
+      let dh = height * factor | 0 // eslint-disable-line no-bitwise
+      // 到最后一步的时候 dw, dh 用目标缩放尺寸，否则会出现最后尺寸偏小的情况
       if (i === steps - 1) {
         dw = originWidth * scale
         dh = originHeight * scale
       }
 
       if (i % 2 === 0) {
-        src = mirror1
-        context = context2
+        src = source
+        context = mctx
       } else {
-        src = mirror2
-        context = context1
+        src = mirror
+        context = sctx
       }
-
+      // 每次画前都清空，避免图像重叠
       this.clear(context, width, height)
       context.drawImage(src, 0, 0, width, height, 0, 0, dw, dh)
       width = dw
       height = dh
     }
 
-    const canvas = src === mirror1 ? mirror2 : mirror1
+    const canvas = src === source ? mirror : source
     // save data
     const data = context.getImageData(0, 0, width, height)
 

--- a/src/utils/compress.ts
+++ b/src/utils/compress.ts
@@ -154,7 +154,7 @@ class Compress {
 
     const { width: originWidth, height: originHeight } = source
 
-    const mirror1 = document.createElement('canvas')
+    const mirror1 = source
     const mirror2 = document.createElement('canvas')
     const context1 = mirror1.getContext('2d')!
     const context2 = mirror2.getContext('2d')!
@@ -168,14 +168,8 @@ class Compress {
 
     let width = originWidth
     let height = originHeight
-    mirror1.width = width
-    mirror1.height = height
     mirror2.width = width
     mirror2.height = height
-
-    // 将源图像画在 mirror1 上
-    this.clear(context1, width, height)
-    context1.drawImage(source, 0, 0, width, height)
 
     let src: CanvasImageSource = mirror1
     let context: CanvasRenderingContext2D = context2


### PR DESCRIPTION
该PR可以修复 issue #416 的问题。

## 问题复现条件

1. 一张带EXIF的jpg图片，且orientation值不为1，为2到8之间。
2. 设置了`maxWidth`或者`maxHeight`，即触发缩放逻辑`doScale`。

## bug出现原因

当图片 exif 的 orientation 不为1，就触发了 `getTransform` 进行旋转矫正。`getCanvas` 中的 `context.transform(...matrix)` 影响了传递给 `doScale` 的 canvas。

## 解决方法

~在 `doScale` 中采用两个新的canvas镜像交替缩放图片，而不直接采用`getCanvas`传递过来的canvas。_（当前PR的做法）_~

新的修复方式是：通过`context.save()`以及`context.restore()`恢复成原来的context。